### PR TITLE
Fix: Center GitHub section headline

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -456,7 +456,7 @@ a:focus-visible,
   font-size: 2rem;
   font-weight: 600;
   margin-bottom: 2rem;
-  text-align: left;
+  text-align: center;
   color: var(--text-primary);
 }
 


### PR DESCRIPTION
Fixes #2

Centered the GitHub section headline to match other section headings throughout the site.

**Changes:**
- Changed `text-align` from 'left' to 'center' for `.github-section h3`
- Now consistent with other section headings like 'Connect & Explore'

Generated with [Claude Code](https://claude.ai/code)