### PR TITLE
Add Strava widget next to GitHub widget

### DIFF
--- a/api/github.js
+++ b/api/github.js
@@ -1,0 +1,110 @@
+// GitHub API endpoint for fetching user activity
+export default async function handler(req, res) {
+  // Set CORS headers
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  try {
+    const username = process.env.GITHUB_USERNAME || 'brettstark73';
+    const token = process.env.GITHUB_TOKEN;
+    
+    const headers = {
+      'User-Agent': 'about-brettstark-site',
+      'Accept': 'application/vnd.github.v3+json',
+    };
+    
+    if (token) {
+      headers['Authorization'] = `token ${token}`;
+    }
+
+    // Fetch user info and repositories in parallel
+    const [userResponse, reposResponse, eventsResponse] = await Promise.all([
+      fetch(`https://api.github.com/users/${username}`, { headers }),
+      fetch(`https://api.github.com/users/${username}/repos?sort=updated&per_page=5`, { headers }),
+      fetch(`https://api.github.com/users/${username}/events/public?per_page=10`, { headers })
+    ]);
+
+    if (!userResponse.ok || !reposResponse.ok || !eventsResponse.ok) {
+      throw new Error('Failed to fetch GitHub data');
+    }
+
+    const user = await userResponse.json();
+    const repos = await reposResponse.json();
+    const events = await eventsResponse.json();
+
+    // Filter for meaningful commit events
+    const recentCommits = events
+      .filter(event => event.type === 'PushEvent')
+      .slice(0, 5)
+      .map(event => ({
+        id: event.id,
+        repo: event.repo.name,
+        message: event.payload.commits[0]?.message || 'No commit message',
+        date: event.created_at,
+        url: `https://github.com/${event.repo.name}`
+      }));
+
+    // Format repository data
+    const topRepos = repos.slice(0, 5).map(repo => ({
+      id: repo.id,
+      name: repo.name,
+      description: repo.description,
+      language: repo.language,
+      stars: repo.stargazers_count,
+      url: repo.html_url,
+      updated: repo.updated_at
+    }));
+
+    const data = {
+      user: {
+        name: user.name,
+        login: user.login,
+        avatar_url: user.avatar_url,
+        public_repos: user.public_repos,
+        followers: user.followers,
+        following: user.following
+      },
+      repos: topRepos,
+      commits: recentCommits,
+      stats: {
+        totalRepos: user.public_repos,
+        totalCommits: recentCommits.length,
+        languages: [...new Set(topRepos.map(repo => repo.language).filter(Boolean))].length,
+        topLanguage: getTopLanguage(topRepos)
+      }
+    };
+
+    res.status(200).json(data);
+  } catch (error) {
+    console.error('GitHub API Error:', error);
+    res.status(500).json({ 
+      error: 'Failed to fetch GitHub data',
+      message: error.message 
+    });
+  }
+}
+
+function getTopLanguage(repos) {
+  const languageCount = {};
+  repos.forEach(repo => {
+    if (repo.language) {
+      languageCount[repo.language] = (languageCount[repo.language] || 0) + 1;
+    }
+  });
+  
+  const sortedLanguages = Object.entries(languageCount)
+    .sort(([,a], [,b]) => b - a);
+    
+  return sortedLanguages[0]?.[0] || 'JavaScript';
+}

--- a/api/strava.js
+++ b/api/strava.js
@@ -1,0 +1,162 @@
+// Strava API endpoint for fetching user activities
+export default async function handler(req, res) {
+  // Set CORS headers
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  try {
+    const accessToken = process.env.STRAVA_ACCESS_TOKEN;
+    
+    if (!accessToken) {
+      // Return mock data when no token is available
+      const mockData = {
+        athlete: {
+          id: 'brett_stark',
+          firstname: 'Brett',
+          lastname: 'Stark',
+          profile_medium: null,
+          city: 'Libertyville',
+          state: 'Illinois',
+          country: 'United States'
+        },
+        activities: [
+          {
+            id: 1,
+            name: 'Morning Run',
+            type: 'Run',
+            distance: 5.2,
+            moving_time: 1380, // 23 minutes
+            total_elevation_gain: 45,
+            start_date: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+            average_speed: 3.77
+          },
+          {
+            id: 2,
+            name: 'Track Workout',
+            type: 'Run',
+            distance: 8.0,
+            moving_time: 2400, // 40 minutes
+            total_elevation_gain: 12,
+            start_date: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+            average_speed: 3.33
+          },
+          {
+            id: 3,
+            name: 'Long Run',
+            type: 'Run',
+            distance: 15.5,
+            moving_time: 4800, // 80 minutes
+            total_elevation_gain: 120,
+            start_date: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+            average_speed: 3.23
+          }
+        ],
+        stats: {
+          totalActivities: 3,
+          totalDistance: 28.7,
+          totalTime: 8580,
+          avgPace: '5:12', // min/km
+          weeklyDistance: 28.7
+        }
+      };
+      
+      res.status(200).json(mockData);
+      return;
+    }
+    
+    const headers = {
+      'Authorization': `Bearer ${accessToken}`,
+      'Accept': 'application/json',
+    };
+
+    // Fetch athlete info and recent activities
+    const [athleteResponse, activitiesResponse] = await Promise.all([
+      fetch('https://www.strava.com/api/v3/athlete', { headers }),
+      fetch('https://www.strava.com/api/v3/athlete/activities?per_page=5', { headers })
+    ]);
+
+    if (!athleteResponse.ok || !activitiesResponse.ok) {
+      throw new Error('Failed to fetch Strava data');
+    }
+
+    const athlete = await athleteResponse.json();
+    const activities = await activitiesResponse.json();
+
+    // Calculate stats
+    const totalDistance = activities.reduce((sum, activity) => sum + (activity.distance / 1000), 0);
+    const totalTime = activities.reduce((sum, activity) => sum + activity.moving_time, 0);
+    const avgSpeed = totalDistance > 0 ? totalTime / totalDistance : 0;
+    const avgPace = avgSpeed > 0 ? formatPace(avgSpeed) : '0:00';
+
+    const data = {
+      athlete: {
+        id: athlete.id,
+        firstname: athlete.firstname,
+        lastname: athlete.lastname,
+        profile_medium: athlete.profile_medium,
+        city: athlete.city,
+        state: athlete.state,
+        country: athlete.country
+      },
+      activities: activities.map(activity => ({
+        id: activity.id,
+        name: activity.name,
+        type: activity.type,
+        distance: Math.round((activity.distance / 1000) * 10) / 10, // km, 1 decimal
+        moving_time: activity.moving_time,
+        total_elevation_gain: activity.total_elevation_gain,
+        start_date: activity.start_date,
+        average_speed: activity.average_speed
+      })),
+      stats: {
+        totalActivities: activities.length,
+        totalDistance: Math.round(totalDistance * 10) / 10,
+        totalTime: totalTime,
+        avgPace: avgPace,
+        weeklyDistance: Math.round(totalDistance * 10) / 10
+      }
+    };
+
+    res.status(200).json(data);
+  } catch (error) {
+    console.error('Strava API Error:', error);
+    res.status(500).json({ 
+      error: 'Failed to fetch Strava data',
+      message: error.message 
+    });
+  }
+}
+
+function formatPace(speedMs) {
+  // Convert m/s to min/km
+  const paceSeconds = 1000 / speedMs; // seconds per km
+  const minutes = Math.floor(paceSeconds / 60);
+  const seconds = Math.floor(paceSeconds % 60);
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function formatTime(seconds) {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+}
+
+function formatDistance(meters) {
+  const km = meters / 1000;
+  return km >= 1 ? `${km.toFixed(1)}km` : `${meters}m`;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -271,33 +271,66 @@
         </div>
       </section>
 
-      <section class="github-section">
+      <section class="activity-section">
         <div class="container">
-          <h3>GitHub</h3>
-          <div class="links-grid">
-            <div class="github-stats-card">
-              <div class="stats-grid">
-                <div class="stat-item">
-                  <div class="stat-number">5</div>
-                  <div class="stat-label">Total Repos</div>
+          <h3>Recent Activity</h3>
+          <div class="activity-widgets">
+            <!-- GitHub Widget -->
+            <div class="activity-widget">
+              <div class="widget-header">
+                <h4>🔧 GitHub</h4>
+                <div class="widget-loading" id="github-loading">Loading...</div>
+              </div>
+              <div class="widget-content" id="github-content" style="display: none;">
+                <div class="github-tabs">
+                  <button class="github-tab active" data-tab="repos">Repositories</button>
+                  <button class="github-tab" data-tab="commits">Recent Commits</button>
                 </div>
-                <div class="stat-item">
-                  <div class="stat-number">57</div>
-                  <div class="stat-label">Total Commits</div>
+                <div class="tab-content">
+                  <div class="github-repos active" id="repos-content">
+                    <!-- Repository list will be populated by JavaScript -->
+                  </div>
+                  <div class="github-commits" id="commits-content">
+                    <!-- Commits list will be populated by JavaScript -->
+                  </div>
                 </div>
-                <div class="stat-item">
-                  <div class="stat-number">3</div>
-                  <div class="stat-label">Languages</div>
-                </div>
-                <div class="stat-item">
-                  <div class="stat-number">C</div>
-                  <div class="stat-label">Top Grade</div>
+                <div class="github-link">
+                  <a href="https://github.com/brettstark73" target="_blank" rel="noopener noreferrer">
+                    View Profile →
+                  </a>
                 </div>
               </div>
-              <div class="github-link">
-                <a href="https://github.com/brettstark73" target="_blank" rel="noopener noreferrer">
-                  View Profile →
-                </a>
+            </div>
+
+            <!-- Strava Widget -->
+            <div class="activity-widget">
+              <div class="widget-header">
+                <h4>🏃‍♂️ Strava</h4>
+                <div class="widget-loading" id="strava-loading">Loading...</div>
+              </div>
+              <div class="widget-content" id="strava-content" style="display: none;">
+                <div class="strava-stats">
+                  <div class="stat-item">
+                    <div class="stat-number" id="strava-weekly-distance">0</div>
+                    <div class="stat-label">Weekly km</div>
+                  </div>
+                  <div class="stat-item">
+                    <div class="stat-number" id="strava-avg-pace">0:00</div>
+                    <div class="stat-label">Avg Pace</div>
+                  </div>
+                  <div class="stat-item">
+                    <div class="stat-number" id="strava-activities">0</div>
+                    <div class="stat-label">Activities</div>
+                  </div>
+                </div>
+                <div class="strava-activities" id="strava-activities-list">
+                  <!-- Activities will be populated by JavaScript -->
+                </div>
+                <div class="strava-link">
+                  <a href="https://www.strava.com/athletes/brettstark" target="_blank" rel="noopener noreferrer">
+                    View Profile →
+                  </a>
+                </div>
               </div>
             </div>
           </div>
@@ -333,5 +366,146 @@
         <p>&copy; 2025 Brett Stark. All rights reserved.</p>
       </div>
     </footer>
+
+    <script>
+      // Activity widgets functionality
+      document.addEventListener('DOMContentLoaded', function() {
+        // Tab switching for GitHub widget
+        const githubTabs = document.querySelectorAll('.github-tab');
+        githubTabs.forEach(tab => {
+          tab.addEventListener('click', function() {
+            const targetTab = this.dataset.tab;
+            
+            // Update active tab
+            githubTabs.forEach(t => t.classList.remove('active'));
+            this.classList.add('active');
+            
+            // Update active content
+            const reposContent = document.getElementById('repos-content');
+            const commitsContent = document.getElementById('commits-content');
+            
+            if (targetTab === 'repos') {
+              reposContent.classList.add('active');
+              commitsContent.classList.remove('active');
+            } else {
+              reposContent.classList.remove('active');
+              commitsContent.classList.add('active');
+            }
+          });
+        });
+
+        // Load GitHub data
+        loadGitHubData();
+        
+        // Load Strava data
+        loadStravaData();
+      });
+
+      async function loadGitHubData() {
+        try {
+          const response = await fetch('/api/github');
+          if (!response.ok) throw new Error('Failed to fetch GitHub data');
+          
+          const data = await response.json();
+          
+          // Hide loading, show content
+          document.getElementById('github-loading').style.display = 'none';
+          document.getElementById('github-content').style.display = 'block';
+          
+          // Populate repositories
+          const reposContainer = document.getElementById('repos-content');
+          reposContainer.innerHTML = data.repos.map(repo => `
+            <div class="github-repo-item">
+              <div class="repo-header">
+                <h5><a href="${repo.url}" target="_blank" rel="noopener noreferrer">${repo.name}</a></h5>
+                <span class="repo-language">${repo.language || 'N/A'}</span>
+              </div>
+              <p class="repo-description">${repo.description || 'No description available'}</p>
+              <div class="repo-stats">
+                <span>⭐ ${repo.stars}</span>
+                <span>Updated ${formatDate(repo.updated)}</span>
+              </div>
+            </div>
+          `).join('');
+          
+          // Populate commits
+          const commitsContainer = document.getElementById('commits-content');
+          commitsContainer.innerHTML = data.commits.map(commit => `
+            <div class="github-commit-item">
+              <div class="commit-header">
+                <a href="${commit.url}" target="_blank" rel="noopener noreferrer">${commit.repo}</a>
+                <span class="commit-date">${formatDate(commit.date)}</span>
+              </div>
+              <p class="commit-message">${commit.message}</p>
+            </div>
+          `).join('');
+          
+        } catch (error) {
+          console.error('Error loading GitHub data:', error);
+          document.getElementById('github-loading').textContent = 'Failed to load GitHub data';
+        }
+      }
+
+      async function loadStravaData() {
+        try {
+          const response = await fetch('/api/strava');
+          if (!response.ok) throw new Error('Failed to fetch Strava data');
+          
+          const data = await response.json();
+          
+          // Hide loading, show content
+          document.getElementById('strava-loading').style.display = 'none';
+          document.getElementById('strava-content').style.display = 'block';
+          
+          // Update stats
+          document.getElementById('strava-weekly-distance').textContent = data.stats.weeklyDistance;
+          document.getElementById('strava-avg-pace').textContent = data.stats.avgPace;
+          document.getElementById('strava-activities').textContent = data.stats.totalActivities;
+          
+          // Populate activities
+          const activitiesContainer = document.getElementById('strava-activities-list');
+          activitiesContainer.innerHTML = data.activities.map(activity => `
+            <div class="strava-activity-item">
+              <div class="activity-header">
+                <h5>${activity.name}</h5>
+                <span class="activity-type">${activity.type}</span>
+              </div>
+              <div class="activity-stats">
+                <span>${activity.distance}km</span>
+                <span>${formatDuration(activity.moving_time)}</span>
+                <span>${formatDate(activity.start_date)}</span>
+              </div>
+            </div>
+          `).join('');
+          
+        } catch (error) {
+          console.error('Error loading Strava data:', error);
+          document.getElementById('strava-loading').textContent = 'Failed to load Strava data';
+        }
+      }
+
+      function formatDate(dateString) {
+        const date = new Date(dateString);
+        const now = new Date();
+        const diffTime = Math.abs(now - date);
+        const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+        
+        if (diffDays === 0) return 'Today';
+        if (diffDays === 1) return 'Yesterday';
+        if (diffDays < 7) return `${diffDays} days ago`;
+        if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`;
+        return date.toLocaleDateString();
+      }
+
+      function formatDuration(seconds) {
+        const hours = Math.floor(seconds / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
+        
+        if (hours > 0) {
+          return `${hours}h ${minutes}m`;
+        }
+        return `${minutes}m`;
+      }
+    </script>
   </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -446,13 +446,14 @@ a:focus-visible,
   }
 }
 
-.github-section {
+/* Activity Section */
+.activity-section {
   background: var(--surface);
   padding: 4rem 0;
   margin-bottom: 4rem;
 }
 
-.github-section h3 {
+.activity-section h3 {
   font-size: 2rem;
   font-weight: 600;
   margin-bottom: 2rem;
@@ -460,29 +461,173 @@ a:focus-visible,
   color: var(--text-primary);
 }
 
-/* Remove the width constraint to match links section */
+.activity-widgets {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  gap: 2rem;
+}
 
-.github-stats-card {
+.activity-widget {
   background: white;
-  padding: 1.5rem;
   border-radius: 12px;
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
+  overflow: hidden;
   transition:
     transform 0.3s ease,
     box-shadow 0.3s ease;
 }
 
-.github-stats-card:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-lg);
+.activity-widget:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-hover);
 }
 
-.stats-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1.5rem;
+.widget-header {
+  padding: 1.5rem 1.5rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.widget-header h4 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.widget-loading {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+}
+
+.widget-content {
+  padding: 1.5rem;
+}
+
+/* GitHub Widget Styles */
+.github-tabs {
+  display: flex;
+  gap: 0.5rem;
   margin-bottom: 1.5rem;
+}
+
+.github-tab {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.github-tab:hover {
+  background: var(--primary-color);
+  color: white;
+  border-color: var(--primary-color);
+}
+
+.github-tab.active {
+  background: var(--primary-color);
+  color: white;
+  border-color: var(--primary-color);
+}
+
+.tab-content {
+  position: relative;
+}
+
+.github-repos,
+.github-commits {
+  display: none;
+}
+
+.github-repos.active,
+.github-commits.active {
+  display: block;
+}
+
+.github-repo-item,
+.github-commit-item {
+  padding: 1rem;
+  margin-bottom: 1rem;
+  background: var(--surface);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  transition: all 0.3s ease;
+}
+
+.github-repo-item:hover,
+.github-commit-item:hover {
+  border-color: var(--primary-color);
+  background: white;
+}
+
+.github-repo-item:last-child,
+.github-commit-item:last-child {
+  margin-bottom: 0;
+}
+
+.repo-header,
+.commit-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.repo-header h5,
+.commit-header a {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--primary-color);
+  text-decoration: none;
+}
+
+.repo-language,
+.activity-type {
+  background: var(--primary-color);
+  color: white;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.commit-date {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.repo-description,
+.commit-message {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin: 0.5rem 0;
+  line-height: 1.4;
+}
+
+.repo-stats,
+.activity-stats {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+/* Strava Widget Styles */
+.strava-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  background: var(--surface);
+  border-radius: 8px;
 }
 
 .stat-item {
@@ -490,8 +635,7 @@ a:focus-visible,
 }
 
 .stat-number {
-  display: block;
-  font-size: 2rem;
+  font-size: 1.5rem;
   font-weight: 700;
   color: var(--primary-color);
   margin-bottom: 0.25rem;
@@ -503,29 +647,91 @@ a:focus-visible,
   font-weight: 500;
 }
 
-.github-link {
-  text-align: center;
-  border-top: 1px solid var(--border);
-  padding-top: 1.5rem;
+.strava-activity-item {
+  padding: 1rem;
+  margin-bottom: 1rem;
+  background: var(--surface);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  transition: all 0.3s ease;
 }
 
-.github-link a {
+.strava-activity-item:hover {
+  border-color: var(--primary-color);
+  background: white;
+}
+
+.strava-activity-item:last-child {
+  margin-bottom: 0;
+}
+
+.activity-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.activity-header h5 {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.github-link,
+.strava-link {
+  text-align: center;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+}
+
+.github-link a,
+.strava-link a {
   color: var(--primary-color);
   text-decoration: none;
   font-weight: 600;
+  font-size: 0.875rem;
   transition: color 0.3s ease;
 }
 
-.github-link a:hover {
+.github-link a:hover,
+.strava-link a:hover {
   color: var(--primary-hover);
 }
 
+/* Responsive adjustments */
 @media (max-width: 768px) {
-  .stats-grid {
-    grid-template-columns: repeat(2, 1fr);
+  .activity-widgets {
+    grid-template-columns: 1fr;
   }
 
-  .github-stats-card {
-    max-width: none;
+  .github-tabs {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .github-tab {
+    font-size: 0.875rem;
+    padding: 0.5rem 1rem;
+  }
+
+  .strava-stats {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .github-commit-item,
+  .github-repo-item,
+  .strava-activity-item {
+    padding: 0.875rem;
+  }
+
+  .widget-content {
+    padding: 1rem;
+  }
+
+  .widget-header {
+    padding: 1rem;
   }
 }


### PR DESCRIPTION
Add dynamic GitHub and Strava activity widgets to replace static GitHub section.

Features:
- GitHub API endpoint for repositories and commits
- Strava API endpoint with mock data for running activities  
- Tab-based interface for GitHub data
- Responsive design for both widgets
- Real-time data loading with error handling

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)